### PR TITLE
タスク詳細取得・表示処理を追加

### DIFF
--- a/react_farm/src/components/TaskItem.tsx
+++ b/react_farm/src/components/TaskItem.tsx
@@ -9,7 +9,10 @@ import { useAppDispatch } from '../app/hooks'
 import { setEditedTask } from '../slices/appSlice'
 import { useMutateTask } from '../hooks/useMutateTask'
 
-const TaskItemMemo: FC<Task> = ({ id, title, description }) => {
+const TaskItemMemo: FC<
+  // &(Intersection):型（属性）を結合。setIdはあらかじめ用意された型を使用
+  Task & { setId: React.Dispatch<React.SetStateAction<string>> }
+> = ({ id, title, description, setId }) => {
   // dispathを使えるようにする
   const dispatch = useAppDispatch()
   
@@ -17,8 +20,8 @@ const TaskItemMemo: FC<Task> = ({ id, title, description }) => {
 
   return (
     <li>
-      {/* タイトル */}
-      <span className="font-bold cursor-pointer">
+      {/* タスクのタイトル（onClickで、クリック時にタイトルのidを更新） */}
+      <span className="font-bold cursor-pointer" onClick={() => setId(id)}>
         {title}
       </span>
 

--- a/react_farm/src/components/Todo.tsx
+++ b/react_farm/src/components/Todo.tsx
@@ -2,6 +2,7 @@
 // Todo（全体？）のコンポーネント
 //////////////////////////////////
 
+import { useState } from 'react'
 import { LogoutIcon } from '@heroicons/react/outline'
 import { ShieldCheckIcon } from '@heroicons/react/solid'
 import { useAppSelector, useAppDispatch } from '../app/hooks'
@@ -10,14 +11,19 @@ import { useProcessAuth } from '../hooks/useProcessAuth'
 import { useProcessTask } from '../hooks/useProcessTask'
 import { useQueryTasks } from '../hooks/useQueryTasks'
 import { useQueryUser } from '../hooks/useQueryUser'
+import { useQuerySingleTask } from '../hooks/useQuerySingleTask'
 import { TaskItem } from './TaskItem'
 
 export const Todo = () => {
+  // ユーザーが選択したタスクのIDを保持
+  const [id, setId] = useState('')
+
   const { logout } = useProcessAuth()
 
   // useQueryのカスタムフックを実行
   const { data: dataUser } = useQueryUser()
   const { data: dataTasks, isLoading: isLoadingTasks } = useQueryTasks()
+  const { data: dataSingleTask, isLoading: isLoadingTask } = useQuerySingleTask(id)
 
   // dispathを使えるようにする
   const dispatch = useAppDispatch()
@@ -102,10 +108,23 @@ export const Todo = () => {
               id={task.id}
               title={task.title}
               description={task.description}
+              setId={setId}  // ユーザーが選択したタスクのID
             />
           ))}
         </ul>
       )}
+
+
+      {/* 以下タスク詳細部分 */}
+      {/* タスク詳細部分タイトル*/}
+      <h2 className="mt-3 font-bold">Selected Task</h2>
+
+      {/* 取得中の場合は「Loading...」を出す */}
+      {isLoadingTask && <p>Loading...</p>}
+      
+      {/* タスクが存在する場合は表示 */}
+      <p className="my-1 text-blue-500 text-sm">{dataSingleTask?.title}</p>
+      <p className="text-blue-500 text-sm">{dataSingleTask?.description}</p>
     </div>
   )
 }

--- a/react_farm/src/hooks/useQuerySingleTask.ts
+++ b/react_farm/src/hooks/useQuerySingleTask.ts
@@ -1,0 +1,60 @@
+//////////////////////////////////////////
+// タスクの詳細を1つ取得するカスタムフック
+//////////////////////////////////////////
+
+import { useQuery } from 'react-query'
+import axios from 'axios'
+import { useAppDispatch } from '../app/hooks'
+import { resetEditedTask, toggleCsrfState } from '../slices/appSlice'
+import { Task } from '../types/types'
+import { useHistory } from 'react-router-dom'
+
+export const useQuerySingleTask = (id: string) => {  // 取得したいIDを受け取る
+  // インスタンス化
+  const history = useHistory()
+  const dispatch = useAppDispatch()
+
+  // タスク詳細取得処理
+  const getSingleTask = async (id: string) => {
+    // axiosのgetで、todo/idのエンドポイントにアクセス
+    const { data } = await axios.get<Task>(  // 返り値は<Task>型を指定（Generics:使用されるまで型が確定しない）
+      `${process.env.REACT_APP_API_URL}/todo/${id}`,
+      {
+        // cookie付きの通信を有効
+        withCredentials: true,
+      }
+    )
+    // 取得したデータ（）を返す
+    return data
+  }
+
+  // useQueryを実行した結果を返す
+  return useQuery({
+    // キャッシュに格納するときのキー（'single'という文字列とid）
+    queryKey: ['single', id],
+    queryFn: () => getSingleTask(id),
+    // useQueryの機能を有効化/無効化
+    enabled: !!id,  // IDが設定されるとTrue
+    // キャッシュのデータを永遠に最新とみなす（再フェッチを行わない）
+    staleTime: Infinity,
+
+    // キャッシュに格納しているタスクの情報が消えるまでの時間（default: 5min）
+    //cacheTime: 300000,
+    
+    // get通信が失敗した場合
+    onError: (err: any) => {
+      // エラーメッセージの表示
+      alert(`${err.response.data.detail}\n${err.message}`)
+      // JWTまたはCSRF tokenが失効している場合
+      if (err.response.data.detail === 'The JWT has expired' ||
+          err.response.data.detail === 'The CSRF token has expired.') {
+        // CSRF tokenを再度取得
+        dispatch(toggleCsrfState())
+        // 編集中のタスクをリセット
+        dispatch(resetEditedTask())
+        // todoからAuthへページ遷移
+        history.push('/')
+      }
+    },
+  })
+}


### PR DESCRIPTION
### 関連するIssue
close #16 

### 説明
- タスク一覧部分のタスク名をクリックすると、該当タスクの詳細情報を取得・表示する機能を実装
- 取得したタスクの情報はキャッシュに格納される

### 上記追加以外の変更点
なし

### 確認したこと
- タスク一覧部分のタスク名をクリックした際、タスク取得処理が成功すること（200番で成功、検証ツール使用）
- 上記でクリックしたタスクの情報がタスク情報表示部分に正常に表示されること
- 上記でクリックしたタスクの情報が正常にキャッシュに格納されること（ReactQueryDevelopTool使用）